### PR TITLE
Conditionally use specific Java version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,35 @@ name: CI Check
 on: [push, pull_request]
 
 jobs:
+  test-501:
+    name: Launch Openfire 5.0.1
+    runs-on: ubuntu-24.04 # For newer curl version
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Openfire
+        uses: ./
+        with:
+          version: '5.0.1'
+
+      - name: Check Admin Console
+        run: |
+          set -e
+          echo "Checking Openfire Admin Console"
+          OPENFIRE_CONSOLE=$(curl -s -o /dev/null -I -w "%{http_code}^%header{Location}" http://127.0.0.1:9090/index.jsp)
+          RESPONSE_CODE=$(echo $OPENFIRE_CONSOLE | cut -d^ -f1)
+          LOCATION=$(echo $OPENFIRE_CONSOLE | cut -d^ -f2)
+          if [ "$RESPONSE_CODE" != "302" ] | [ "$LOCATION" != '/login.jsp?url=%2Findex.jsp' ]; then
+            echo "Openfire Admin Console is not available"
+            echo "Response code: $RESPONSE_CODE and Location: $LOCATION"
+            exit 1
+          else
+            echo "Admin console up and redirecting to login page"
+          fi
+
   test-490:
     name: Launch Openfire 4.9.0
     runs-on: ubuntu-24.04 # For newer curl version
@@ -81,7 +110,7 @@ jobs:
           OPENFIRE_CONSOLE=$(curl -s -o /dev/null -I -w "%{http_code}^%header{Location}" http://127.0.0.1:9090/index.jsp)
           RESPONSE_CODE=$(echo $OPENFIRE_CONSOLE | cut -d^ -f1)
           LOCATION=$(echo $OPENFIRE_CONSOLE | cut -d^ -f2)
-          if [ "$RESPONSE_CODE" != "302" ] | [ "$LOCATION" != 'http://127.0.0.1:9090/login.jsp?url=%2Findex.jsp' ]; then
+          if [ "$RESPONSE_CODE" != "302" ] | [ "$LOCATION" != '/login.jsp?url=%2Findex.jsp' ]; then
             echo "Openfire Admin Console is not available"
             echo "Response code: $RESPONSE_CODE and Location: $LOCATION"
             exit 1

--- a/action.yml
+++ b/action.yml
@@ -39,28 +39,14 @@ runs:
         fi
       shell: bash
 
-    - name: Setup Java 11
+    - name: Setup Java
       uses: actions/setup-java@v4
-      if: ${{ steps.variables.outputs.JAVA_VERSION == '11' }}
       with:
-        java-version: 11
+        java-version: ${{ steps.variables.outputs.JAVA_VERSION }}
         distribution: zulu
 
-    - name: Setup Java 17
-      uses: actions/setup-java@v4
-      if: ${{ steps.variables.outputs.JAVA_VERSION == '17' }}
-      with:
-        java-version: 17
-        distribution: zulu
-
-    - name: Set JAVA_HOME to use Java 11
-      if: ${{ steps.variables.outputs.JAVA_VERSION == '11' }}
-      run: echo "JAVA_HOME=$(echo $JAVA_HOME_11_X64)" >> $GITHUB_ENV
-      shell: bash
-
-    - name: Set JAVA_HOME to use Java 17
-      if: ${{ steps.variables.outputs.JAVA_VERSION == '17' }}
-      run: echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> $GITHUB_ENV
+    - name: Set JAVA_HOME
+      run: echo "JAVA_HOME=$(eval echo \$JAVA_HOME_${{ steps.variables.outputs.JAVA_VERSION }}_X64)" >> $GITHUB_ENV
       shell: bash
 
     - uses: dsaltares/fetch-gh-release-asset@1.1.2

--- a/action.yml
+++ b/action.yml
@@ -25,27 +25,38 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Calculate Java version
+      id: java_version
+      # Should be 17, unless we need 11. This is only for Openfire 3.x and 4.x versions. A daily build will always be after 5.x.
+      run: |
+        if [[ "${{ inputs.daily }}" == "false" && ( "${{ inputs.version }}" == 3.* || "${{ inputs.version }}" == 4.* ) ]]; then
+          echo "java_version=11" >> $GITHUB_OUTPUT
+        else
+          echo "java_version=17" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
     - name: Setup Java 11
       uses: actions/setup-java@v4
-      if: ${{ inputs.daily == 'false' || startsWith( inputs.version, '3.' ) || startsWith( inputs.version, '4.' ) }}
+      if: ${{ steps.java_version.outputs.java_version == '11' }}
       with:
         java-version: 11
         distribution: zulu
 
     - name: Setup Java 17
       uses: actions/setup-java@v4
-      if: ${{ inputs.daily == 'true' || (!startsWith( inputs.version, '3.' ) && !startsWith( inputs.version, '4.' )) }}
+      if: ${{ steps.java_version.outputs.java_version == '17' }}
       with:
         java-version: 17
         distribution: zulu
 
     - name: Set JAVA_HOME to use Java 11
-      if: ${{ inputs.daily == 'false' || startsWith( inputs.version, '3.' ) || startsWith( inputs.version, '4.' ) }}
+      if: ${{ steps.java_version.outputs.java_version == '11' }}
       run: echo "JAVA_HOME=$(echo $JAVA_HOME_11_X64)" >> $GITHUB_ENV
       shell: bash
 
     - name: Set JAVA_HOME to use Java 17
-      if: ${{ inputs.daily == 'true' || (!startsWith( inputs.version, '3.' ) && !startsWith( inputs.version, '4.' )) }}
+      if: ${{ steps.java_version.outputs.java_version == '17' }}
       run: echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> $GITHUB_ENV
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -25,47 +25,42 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Calculate Java version
-      id: java_version
-      # Should be 17, unless we need 11. This is only for Openfire 3.x and 4.x versions. A daily build will always be after 5.x.
-      run: |
-        if [[ "${{ inputs.daily }}" == "false" && ( "${{ inputs.version }}" == 3.* || "${{ inputs.version }}" == 4.* ) ]]; then
-          echo "java_version=11" >> $GITHUB_OUTPUT
-        else
-          echo "java_version=17" >> $GITHUB_OUTPUT
-        fi
-      shell: bash
-
-    - name: Setup Java 11
-      uses: actions/setup-java@v4
-      if: ${{ steps.java_version.outputs.java_version == '11' }}
-      with:
-        java-version: 11
-        distribution: zulu
-
-    - name: Setup Java 17
-      uses: actions/setup-java@v4
-      if: ${{ steps.java_version.outputs.java_version == '17' }}
-      with:
-        java-version: 17
-        distribution: zulu
-
-    - name: Set JAVA_HOME to use Java 11
-      if: ${{ steps.java_version.outputs.java_version == '11' }}
-      run: echo "JAVA_HOME=$(echo $JAVA_HOME_11_X64)" >> $GITHUB_ENV
-      shell: bash
-
-    - name: Set JAVA_HOME to use Java 17
-      if: ${{ steps.java_version.outputs.java_version == '17' }}
-      run: echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> $GITHUB_ENV
-      shell: bash
-
     - name: Set variables
       id: variables
       run: |
         OPENFIRE_VERSION=${{ inputs.version }}
         echo "OPENFIRE_VERSION=${OPENFIRE_VERSION}" >> $GITHUB_OUTPUT
         echo "OPENFIRE_VERSION_UNDERSCORE=${OPENFIRE_VERSION//./_}" >> $GITHUB_OUTPUT
+
+        if [[ "${{ inputs.daily }}" == "false" && ( "${{ inputs.version }}" == 3.* || "${{ inputs.version }}" == 4.* ) ]]; then
+          echo "JAVA_VERSION=11" >> $GITHUB_OUTPUT
+        else
+          echo "JAVA_VERSION=17" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
+    - name: Setup Java 11
+      uses: actions/setup-java@v4
+      if: ${{ steps.variables.outputs.JAVA_VERSION == '11' }}
+      with:
+        java-version: 11
+        distribution: zulu
+
+    - name: Setup Java 17
+      uses: actions/setup-java@v4
+      if: ${{ steps.variables.outputs.JAVA_VERSION == '17' }}
+      with:
+        java-version: 17
+        distribution: zulu
+
+    - name: Set JAVA_HOME to use Java 11
+      if: ${{ steps.variables.outputs.JAVA_VERSION == '11' }}
+      run: echo "JAVA_HOME=$(echo $JAVA_HOME_11_X64)" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Set JAVA_HOME to use Java 17
+      if: ${{ steps.variables.outputs.JAVA_VERSION == '17' }}
+      run: echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> $GITHUB_ENV
       shell: bash
 
     - uses: dsaltares/fetch-gh-release-asset@1.1.2

--- a/action.yml
+++ b/action.yml
@@ -25,13 +25,28 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-java@v4
+    - name: Setup Java 11
+      uses: actions/setup-java@v4
+      if: ${{ inputs.daily == 'false' || startsWith( inputs.version, '3.' ) || startsWith( inputs.version, '4.' ) }}
       with:
         java-version: 11
         distribution: zulu
 
+    - name: Setup Java 17
+      uses: actions/setup-java@v4
+      if: ${{ inputs.daily == 'true' || (!startsWith( inputs.version, '3.' ) && !startsWith( inputs.version, '4.' )) }}
+      with:
+        java-version: 17
+        distribution: zulu
+
     - name: Set JAVA_HOME to use Java 11
+      if: ${{ inputs.daily == 'false' || startsWith( inputs.version, '3.' ) || startsWith( inputs.version, '4.' ) }}
       run: echo "JAVA_HOME=$(echo $JAVA_HOME_11_X64)" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Set JAVA_HOME to use Java 17
+      if: ${{ inputs.daily == 'true' || (!startsWith( inputs.version, '3.' ) && !startsWith( inputs.version, '4.' )) }}
+      run: echo "JAVA_HOME=$(echo $JAVA_HOME_17_X64)" >> $GITHUB_ENV
       shell: bash
 
     - name: Set variables


### PR DESCRIPTION
For Openfire 3.x and 4.x use Java 11, for other versions, use Java 17.
    
Additionally, the 'Location' header as returned by the HTTP response for the admin console seems to have been slightly different with Openfire 5.0.0. This commit allows for that variation.
    
fixes #2
