### PR TITLE
Ci improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI Check
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test-501:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run Openfire
         uses: ./
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run Openfire
         uses: ./
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run Openfire
         uses: ./
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run Openfire
         uses: ./
@@ -126,7 +126,7 @@ jobs:
       fail-fast: false
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download Plugin
         run: |

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
       shell: bash
 
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: ${{ steps.variables.outputs.JAVA_VERSION }}
         distribution: zulu


### PR DESCRIPTION
- Bump a bunch of actions to prevent node v20 warnings (although I think we're still left with 1 that has no release upstream)
- Don't test every commit to PRs, else we get 2 action runs - wasted compute